### PR TITLE
Pidigits and JSONParseDom

### DIFF
--- a/benchmarks.rb
+++ b/benchmarks.rb
@@ -631,7 +631,7 @@ RUNS = [
     dir: "/src/crystal",
     container: "crystal",
     group: :prod,
-    deps_cmd: "mkdir -p target",
+    deps_cmd: "mkdir -p target ; shards install",
   ),
 
   # ======================================= D ======================================================

--- a/crystal/main.cr
+++ b/crystal/main.cr
@@ -3,6 +3,7 @@ require "big"
 require "cryyjson"
 require "json"
 require "complex"
+require "mut_gmp"
 
 puts "start: #{Time.local.to_unix_ms}"
 Benchmark.run(ARGV[1]?)
@@ -193,35 +194,72 @@ class Pidigits < Benchmark
   def run(iteration_id)
     i = 0
     k = 0
-    ns = BigInt.new("0")
-    a = BigInt.new("0")
-    t = 0
-    u = BigInt.new("0")
+    ns = MutGMP::MpZ.new(0)
+    a = MutGMP::MpZ.new(0)
+    t = MutGMP::MpZ.new(0)
+    u = MutGMP::MpZ.new(0)
     k1 = 1
-    n = 1.to_big_i
-    d = 1.to_big_i
+    n = MutGMP::MpZ.new(1)
+    d = MutGMP::MpZ.new(1)
 
-    while true
+    # Temporary variables for intermediate calculations
+    tmp1 = MutGMP::MpZ.new(0)
+    tmp2 = MutGMP::MpZ.new(0)
+
+    loop do
       k += 1
-      t = n << 1
-      n *= k
+      # t = n << 1
+      tmp1.set!(n)
+      tmp1.shl!(1)
+      t.set!(tmp1)
+
+      # n *= k
+      n.mul!(k)
+
       k1 += 2
-      a = (a + t) * k1
-      d *= k1
+
+      # a = (a + t) * k1
+      tmp1.set!(a)
+      tmp1.add!(t)
+      tmp1.mul!(k1)
+      a.set!(tmp1)
+
+      # d *= k1
+      d.mul!(k1)
+
       if a >= n
-        t, u = (n * 3 + a).divmod(d)
-        u += n
-        if d > u
-          ns = ns * 10 + t
+        # t, u = (n * 3 + a).divmod(d)
+        tmp1.set!(n)
+        tmp1.mul!(3)
+        tmp1.add!(a)
+        # tmp1 is now numerator
+
+        # Use GMP's fdiv_qr for efficient divmod (quotient in t, remainder in u)
+        LibGMP.fdiv_qr(t.to_unsafe, u.to_unsafe, tmp1.to_unsafe, d.to_unsafe)
+
+        # u += n
+        u.add!(n)
+
+        if d >= u
+          # ns = ns * 10 + t
+          ns.mul!(10)
+          ns.add!(t)
+
           i += 1
           if i % 10 == 0
             @result << "%010d\t:%d\n" % {ns.to_u64, i}
-            ns = 0
+            ns.set!(0)
           end
           break if i >= @nn
 
-          a = (a - (d * t)) * 10
-          n *= 10
+          # a = (a - (d * t)) * 10
+          tmp1.set!(d)
+          tmp1.mul!(t)
+          a.sub!(tmp1)
+          a.mul!(10)
+
+          # n *= 10
+          n.mul!(10)
         end
       end
     end
@@ -507,7 +545,7 @@ class Fannkuchredux < Benchmark
     maxFlipsCount = permCount = checksum = 0
     r = n
 
-    while true
+    loop do
       while r > 1
         count[r - 1] = r
         r -= 1
@@ -528,7 +566,7 @@ class Fannkuchredux < Benchmark
       maxFlipsCount = flipsCount if flipsCount > maxFlipsCount
       checksum += (permCount % 2 == 0) ? flipsCount : -flipsCount
 
-      while true
+      loop do
         return {checksum, maxFlipsCount} if r == n
 
         perm0 = perm1[0]
@@ -3624,7 +3662,7 @@ class BWTHuffEncode < Benchmark
 
     private def sift_down(index : Int32)
       size = @heap.size
-      while true
+      loop do
         left = index * 2 + 1
         right = index * 2 + 2
         smallest = index

--- a/crystal/main.cr
+++ b/crystal/main.cr
@@ -1,5 +1,6 @@
-require "big"
 require "base64"
+require "big"
+require "cryyjson"
 require "json"
 require "complex"
 
@@ -192,10 +193,10 @@ class Pidigits < Benchmark
   def run(iteration_id)
     i = 0
     k = 0
-    ns = 0.to_big_i
-    a = 0.to_big_i
+    ns = BigInt.new("0")
+    a = BigInt.new("0")
     t = 0
-    u = 0.to_big_i
+    u = BigInt.new("0")
     k1 = 1
     n = 1.to_big_i
     d = 1.to_big_i
@@ -1326,7 +1327,7 @@ end
 
 class JsonParseDom < Benchmark
   def calc(text)
-    jobj = JSON.parse(text)
+    jobj = Cryyjson.parse(text)
     coordinates = jobj["coordinates"].as_a
     len = coordinates.size.to_f
     x = y = z = 0.0

--- a/crystal/shard.lock
+++ b/crystal/shard.lock
@@ -1,0 +1,10 @@
+version: 2.0
+shards:
+  cryyjson:
+    git: https://github.com/syeopite/cryyjson.git
+    version: 0.1.0+git.commit.2b818b5ae72790e75a9237a33789436dcdbfc3b3
+
+  mut_gmp:
+    git: https://github.com/ralsina/mut_gmp.git
+    version: 0.1.0+git.commit.0c9c4dcc45f7f6ea2c10d463d1e215e8521e02d1
+

--- a/crystal/shard.yml
+++ b/crystal/shard.yml
@@ -1,0 +1,6 @@
+name: LangArena
+version: 0.1.0
+
+dependencies:
+  cryyjson:
+    github: syeopite/cryyjson

--- a/crystal/shard.yml
+++ b/crystal/shard.yml
@@ -4,3 +4,5 @@ version: 0.1.0
 dependencies:
   cryyjson:
     github: syeopite/cryyjson
+  mut_gmp:
+    github: ralsina/mut_gmp


### PR DESCRIPTION
# Pydigits

The main slowdown is that crystal's Big Ints are immutable, so each calculation involved instantiating multiple objects, while other languages could take advantage of GMP's mutable objects.

So, I threw together a mutable GMP wrapper (just to keep the code clean) and it's now about 4x faster

# JSONParseDom

Just used cryyjson and it's faster :-)