### PR TITLE
Port Rust to use SIMD

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,16 +12,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.23.1"
+name = "base64-simd"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64-simd",
  "once_cell",
  "rayon",
  "regex",
@@ -133,6 +137,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -367,6 +377,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wasi"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +44,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simd-csv",
+ "simd-json",
  "tokio",
 ]
 
@@ -85,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +111,42 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -130,6 +185,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -221,6 +285,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +332,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -318,6 +408,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-json"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebe141eb4a23ecc4d5de93fa5b139ac65dc07c38037a2fe9a8fb7c9d36bd832"
+dependencies = [
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +487,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "value-trait"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vsimd"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1"
 regex = "1.12"
 once_cell = "1.18"
 base64-simd = "0.8"
+simd-json = "0.18"
 simd-csv = "0.13"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1.12"
 once_cell = "1.18"
-base64 = "0.23"
+base64-simd = "0.8"
 simd-csv = "0.13"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/rust/src/benchmarks/base64_decode.rs
+++ b/rust/src/benchmarks/base64_decode.rs
@@ -1,6 +1,6 @@
 use super::super::{helper, Benchmark};
 use crate::config_i64;
-use base64::{engine::general_purpose, Engine as _};
+use base64_simd::STANDARD;
 
 pub struct Base64Decode {
     str2_encoded: String,
@@ -12,8 +12,8 @@ impl Base64Decode {
     pub fn new() -> Self {
         let n = config_i64("Base64::Decode", "size");
         let str_data = "a".repeat(n as usize);
-        let str2_encoded = general_purpose::STANDARD.encode(&str_data);
-        let str3_decoded = general_purpose::STANDARD.decode(&str2_encoded).unwrap();
+        let str2_encoded = STANDARD.encode_to_string(str_data.as_bytes());
+        let str3_decoded = STANDARD.decode_to_vec(&str2_encoded).unwrap();
 
         Self {
             str2_encoded,
@@ -29,9 +29,7 @@ impl Benchmark for Base64Decode {
     }
 
     fn run(&mut self, _iteration_id: i64) {
-        self.str3_decoded = general_purpose::STANDARD
-            .decode(&self.str2_encoded)
-            .unwrap();
+        self.str3_decoded = STANDARD.decode_to_vec(&self.str2_encoded).unwrap();
         self.result_val = self.result_val.wrapping_add(self.str3_decoded.len() as u32);
     }
 

--- a/rust/src/benchmarks/base64_encode.rs
+++ b/rust/src/benchmarks/base64_encode.rs
@@ -1,6 +1,6 @@
 use super::super::{helper, Benchmark};
 use crate::config_i64;
-use base64::{engine::general_purpose, Engine as _};
+use base64_simd::STANDARD;
 
 pub struct Base64Encode {
     str_data: String,
@@ -12,7 +12,7 @@ impl Base64Encode {
     pub fn new() -> Self {
         let n = config_i64("Base64::Encode", "size");
         let str_data = "a".repeat(n as usize);
-        let str2_encoded = general_purpose::STANDARD.encode(&str_data);
+        let str2_encoded = STANDARD.encode_to_string(str_data.as_bytes());
         Self {
             str_data,
             str2_encoded,
@@ -27,7 +27,7 @@ impl Benchmark for Base64Encode {
     }
 
     fn run(&mut self, _iteration_id: i64) {
-        self.str2_encoded = general_purpose::STANDARD.encode(&self.str_data);
+        self.str2_encoded = STANDARD.encode_to_string(self.str_data.as_bytes());
         self.result_val = self.result_val.wrapping_add(self.str2_encoded.len() as u32);
     }
 

--- a/rust/src/benchmarks/json_parse_dom.rs
+++ b/rust/src/benchmarks/json_parse_dom.rs
@@ -1,6 +1,6 @@
 use super::super::{helper, Benchmark};
 use crate::config_i64;
-use serde_json::Value;
+use simd_json::prelude::*;
 
 pub struct JsonParseDom {
     n: i64,
@@ -20,18 +20,19 @@ impl JsonParseDom {
     }
 
     fn calc(&self, text: &str) -> (f64, f64, f64) {
-        let json: Value = serde_json::from_str(text).unwrap();
-        let coordinates = json["coordinates"].as_array().unwrap();
+        let mut input = text.as_bytes().to_vec();
+        let tape = simd_json::to_tape(&mut input).unwrap();
+        let coordinates = tape.as_value().get_array("coordinates").unwrap();
         let len = coordinates.len() as f64;
 
         let mut x = 0.0;
         let mut y = 0.0;
         let mut z = 0.0;
 
-        for coord in coordinates {
-            x += coord["x"].as_f64().unwrap();
-            y += coord["y"].as_f64().unwrap();
-            z += coord["z"].as_f64().unwrap();
+        for coord in &coordinates {
+            x += coord.get("x").unwrap().cast_f64().unwrap();
+            y += coord.get("y").unwrap().cast_f64().unwrap();
+            z += coord.get("z").unwrap().cast_f64().unwrap();
         }
 
         (x / len, y / len, z / len)
@@ -66,3 +67,4 @@ impl Benchmark for JsonParseDom {
         self.result_val
     }
 }
+


### PR DESCRIPTION
I've decided to take a look at your Rust implementations, and see if there is anything to be won performance-wise there.
This is going to be a series of an increasingly _whacky_ PRs; this is the first one, the safest one and with the most obvious performance gains.

I assume SIMD is allowed (already used by your C and C++ implementations), and my local benchmarks are showing 5× increase for Base64 benchmark, 10× for Json.


I'm not committing my correctness tests (otherwise those would be counted against line count by your tooling), but I've done some testing to ensure that the modified variant stays true to the original