### PR TITLE
Rust ownership improvements

### DIFF
--- a/rust/src/benchmarks/binarytrees.rs
+++ b/rust/src/benchmarks/binarytrees.rs
@@ -8,23 +8,17 @@ struct TreeNode {
 }
 
 impl TreeNode {
-    fn new(item: i32, depth: i32) -> Self {
+    fn new(item: i32, depth: i32) -> Box<Self> {
+        let mut node = Box::new(Self {
+            left: None,
+            right: None,
+            item,
+        });
         if depth > 0 {
-            let left = Box::new(TreeNode::new(item - (1 << (depth - 1)), depth - 1));
-            let right = Box::new(TreeNode::new(item + (1 << (depth - 1)), depth - 1));
-
-            Self {
-                left: Some(left),
-                right: Some(right),
-                item,
-            }
-        } else {
-            Self {
-                left: None,
-                right: None,
-                item,
-            }
+            node.left = Some(Self::new(item - (1 << (depth - 1)), depth - 1));
+            node.right = Some(Self::new(item + (1 << (depth - 1)), depth - 1));
         }
+        node
     }
 
     fn sum(&self) -> u32 {
@@ -59,7 +53,7 @@ impl Benchmark for BinarytreesObj {
     }
 
     fn run(&mut self, _iteration_id: i64) {
-        let root = Box::new(TreeNode::new(0, self.n as i32));
+        let root = TreeNode::new(0, self.n as i32);
         self.result_val = self.result_val.wrapping_add(root.sum());
     }
 

--- a/rust/src/benchmarks/calculator_ast.rs
+++ b/rust/src/benchmarks/calculator_ast.rs
@@ -112,9 +112,7 @@ impl Benchmark for CalculatorAst {
     }
 
     fn run(&mut self, _iteration_id: i64) {
-        let mut parser = Parser::new(&self.text);
-        parser.parse();
-        self.expressions = parser.expressions;
+        self.expressions = Parser::new(&self.text).parse();
         self.result_val = self.result_val.wrapping_add(self.expressions.len() as u32);
 
         if let Some(Node::Assignment(var, _)) = self.expressions.last() {
@@ -147,7 +145,7 @@ impl Parser {
         }
     }
 
-    fn parse(&mut self) -> Vec<Node> {
+    fn parse(mut self) -> Vec<Node> {
         while self.pos < self.chars.len() {
             self.skip_whitespace();
             if self.pos >= self.chars.len() {
@@ -167,7 +165,7 @@ impl Parser {
             }
         }
 
-        self.expressions.clone()
+        self.expressions
     }
 
     fn parse_expression(&mut self) -> Node {

--- a/rust/src/benchmarks/compress.rs
+++ b/rust/src/benchmarks/compress.rs
@@ -888,45 +888,35 @@ impl LZWEncode {
         }
     }
 
-    fn lzw_encode(&self, input: &[u8]) -> LZWResult {
+    fn lzw_encode(input: &[u8]) -> LZWResult {
         if input.is_empty() {
             return LZWResult::new();
         }
 
         let mut dict = HashMap::with_capacity(4096);
         for i in 0..256 {
-            let s = String::from_utf8_lossy(&[i as u8]).to_string();
-            dict.insert(s, i);
+            dict.insert(vec![i as u8], i);
         }
-
         let mut next_code = 256;
-
         let mut result = Vec::with_capacity(input.len() * 2);
+        let mut current = vec![input[0]];
 
-        let current_str = String::from_utf8_lossy(&[input[0]]).to_string();
-        let mut current = current_str;
-
-        for i in 1..input.len() {
-            let next_char_str = String::from_utf8_lossy(&[input[i]]).to_string();
-            let new_str = current.clone() + &next_char_str;
-
-            if dict.contains_key(&new_str) {
-                current = new_str;
-            } else {
-                let code = dict[&current];
+        for &byte in &input[1..] {
+            current.push(byte);
+            if !dict.contains_key(&current) {
+                let code = dict[&current[..current.len() - 1]];
                 result.push(((code >> 8) & 0xFF) as u8);
                 result.push((code & 0xFF) as u8);
 
-                dict.insert(new_str, next_code);
+                dict.insert(current, next_code);
                 next_code += 1;
-                current = next_char_str;
+                current = vec![byte];
             }
         }
 
         let code = dict[&current];
         result.push(((code >> 8) & 0xFF) as u8);
         result.push((code & 0xFF) as u8);
-
         LZWResult { data: result }
     }
 }
@@ -941,7 +931,7 @@ impl Benchmark for LZWEncode {
     }
 
     fn run(&mut self, _iteration_id: i64) {
-        self.encoded = self.lzw_encode(&self.test_data);
+        self.encoded = Self::lzw_encode(&self.test_data);
         self.result_val = self.result_val.wrapping_add(self.encoded.data.len() as u32);
     }
 
@@ -976,46 +966,34 @@ fn lzw_decode(encoded: &LZWResult) -> Vec<u8> {
         return Vec::new();
     }
 
-    let mut dict: Vec<String> = Vec::with_capacity(4096);
+    assert_eq!(encoded.data.len() % 2, 0, "Decode error: incomplete code");
+
+    let mut dict: Vec<Vec<u8>> = Vec::with_capacity(4096);
     for i in 0..256 {
-        dict.push(String::from_utf8_lossy(&[i as u8]).to_string());
+        dict.push(vec![i as u8]);
     }
 
     let mut result = Vec::with_capacity(encoded.data.len() * 2);
-    let data = &encoded.data;
-    let mut pos = 0;
+    let mut codes = encoded.data.chunks_exact(2);
+    let first = codes.next().unwrap();
+    let mut old_code = u16::from_be_bytes([first[0], first[1]]) as usize;
+    result.extend_from_slice(&dict[old_code]);
 
-    let high = data[pos] as u16;
-    let low = data[pos + 1] as u16;
-    let old_code = ((high as usize) << 8) | (low as usize);
-    pos += 2;
-
-    let old_str = dict[old_code].clone();
-    result.extend_from_slice(old_str.as_bytes());
-
-    let mut next_code = 256;
-    let mut old_str = old_str;
-
-    while pos < data.len() {
-        let high = data[pos] as u16;
-        let low = data[pos + 1] as u16;
-        let new_code = ((high as usize) << 8) | (low as usize);
-        pos += 2;
-
-        let new_str = if new_code < dict.len() {
-            dict[new_code].clone()
-        } else if new_code == next_code {
-            old_str.clone() + &old_str[0..1]
+    for bytes in codes {
+        let new_code = u16::from_be_bytes([bytes[0], bytes[1]]) as usize;
+        let mut entry = dict[old_code].clone();
+        if new_code < dict.len() {
+            entry.push(dict[new_code][0]);
+            result.extend_from_slice(&dict[new_code]);
+        } else if new_code == dict.len() {
+            entry.push(entry[0]);
+            result.extend_from_slice(&entry);
         } else {
             panic!("Decode error");
-        };
+        }
 
-        result.extend_from_slice(new_str.as_bytes());
-
-        dict.push(old_str.clone() + &new_str[0..1]);
-        next_code += 1;
-
-        old_str = new_str;
+        dict.push(entry);
+        old_code = new_code;
     }
 
     result
@@ -1050,3 +1028,4 @@ impl Benchmark for LZWDecode {
         res
     }
 }
+

--- a/rust/src/benchmarks/distance.rs
+++ b/rust/src/benchmarks/distance.rs
@@ -201,10 +201,10 @@ impl NGram {
                 | ((s2_bytes[i + 2] as u32) << 8)
                 | (s2_bytes[i + 3] as u32);
 
-            let _ = *grams2.entry(gram).and_modify(|e| *e += 1).or_insert(1);
+            let count2 = grams2.entry(gram).and_modify(|e| *e += 1).or_insert(1);
 
             if let Some(&count1) = grams1.get(&gram) {
-                if grams2[&gram] <= count1 {
+                if *count2 <= count1 {
                     intersection += 1;
                 }
             }

--- a/rust/src/benchmarks/game_of_life.rs
+++ b/rust/src/benchmarks/game_of_life.rs
@@ -1,13 +1,13 @@
 use super::super::{helper, Benchmark};
 use crate::config_i64;
 
-struct Cell<'a> {
+struct Cell {
     alive: bool,
     next_state: bool,
-    neighbors: Vec<&'a Cell<'a>>,
+    neighbors: Vec<usize>,
 }
 
-impl<'a> Cell<'a> {
+impl Cell {
     fn new(alive: bool) -> Self {
         Self {
             alive,
@@ -16,17 +16,21 @@ impl<'a> Cell<'a> {
         }
     }
 
-    fn add_neighbor(&mut self, cell: &'a Cell<'a>) {
+    fn add_neighbor(&mut self, cell: usize) {
         self.neighbors.push(cell);
     }
 
-    fn compute_next_state(&mut self) {
-        let alive_neighbors = self.neighbors.iter().filter(|n| n.alive).count();
+    fn compute_next_state(&self, cells: &[Cell]) -> bool {
+        let alive_neighbors = self
+            .neighbors
+            .iter()
+            .filter(|&&idx| cells[idx].alive)
+            .count();
 
         if self.alive {
-            self.next_state = alive_neighbors == 2 || alive_neighbors == 3
+            alive_neighbors == 2 || alive_neighbors == 3
         } else {
-            self.next_state = alive_neighbors == 3
+            alive_neighbors == 3
         }
     }
 
@@ -35,44 +39,28 @@ impl<'a> Cell<'a> {
     }
 }
 
-struct Grid<'a> {
+struct Grid {
     width: usize,
     height: usize,
-    cells: Vec<Vec<Cell<'a>>>,
+    cells: Vec<Cell>,
 }
 
-impl<'a> Grid<'a> {
+impl Grid {
     fn new(width: usize, height: usize) -> Self {
         let mut grid = Grid {
             width,
             height,
-            cells: Vec::with_capacity(height),
+            cells: (0..width * height).map(|_| Cell::new(false)).collect(),
         };
-
-        for _ in 0..height {
-            let mut row = Vec::with_capacity(width);
-            for _ in 0..width {
-                row.push(Cell::new(false));
-            }
-            grid.cells.push(row);
-        }
 
         grid.link_neighbors();
         grid
     }
 
     fn link_neighbors(&mut self) {
-        let cells_ref: Vec<Vec<*const Cell<'a>>> = (0..self.height)
-            .map(|y| {
-                (0..self.width)
-                    .map(|x| &self.cells[y][x] as *const Cell)
-                    .collect()
-            })
-            .collect();
-
         for y in 0..self.height {
             for x in 0..self.width {
-                let cell = &mut self.cells[y][x];
+                let cell = &mut self.cells[y * self.width + x];
 
                 for dy in -1..=1 {
                     for dx in -1..=1 {
@@ -84,8 +72,7 @@ impl<'a> Grid<'a> {
                             ((y as i32 + dy + self.height as i32) % self.height as i32) as usize;
                         let nx = ((x as i32 + dx + self.width as i32) % self.width as i32) as usize;
 
-                        let neighbor = unsafe { &*cells_ref[ny][nx] };
-                        cell.add_neighbor(neighbor);
+                        cell.add_neighbor(ny * self.width + nx);
                     }
                 }
             }
@@ -93,42 +80,31 @@ impl<'a> Grid<'a> {
     }
 
     fn next_generation(&mut self) {
-        self.cells.iter_mut().for_each(|row| {
-            row.iter_mut().for_each(|cell| {
-                cell.compute_next_state();
-            });
-        });
-        self.cells.iter_mut().for_each(|row| {
-            row.iter_mut().for_each(|cell| {
-                cell.update();
-            });
-        });
+        for i in 0..self.cells.len() {
+            self.cells[i].next_state = self.cells[i].compute_next_state(&self.cells);
+        }
+        for cell in &mut self.cells {
+            cell.update();
+        }
     }
 
     fn count_alive(&self) -> u32 {
-        self.cells
-            .iter()
-            .flat_map(|row| row.iter())
-            .filter(|cell| cell.alive)
-            .count() as u32
+        self.cells.iter().filter(|cell| cell.alive).count() as u32
     }
 
     fn compute_hash(&self) -> u32 {
         const FNV_OFFSET_BASIS: u32 = 2166136261;
         const FNV_PRIME: u32 = 16777619;
 
-        self.cells
-            .iter()
-            .flat_map(|row| row.iter())
-            .fold(FNV_OFFSET_BASIS, |hash, cell| {
-                let alive = if cell.alive { 1_u32 } else { 0_u32 };
-                (hash ^ alive).wrapping_mul(FNV_PRIME)
-            })
+        self.cells.iter().fold(FNV_OFFSET_BASIS, |hash, cell| {
+            let alive = if cell.alive { 1_u32 } else { 0_u32 };
+            (hash ^ alive).wrapping_mul(FNV_PRIME)
+        })
     }
 }
 
 pub struct GameOfLife {
-    grid: Grid<'static>,
+    grid: Grid,
 }
 
 impl GameOfLife {
@@ -150,7 +126,7 @@ impl Benchmark for GameOfLife {
         for y in 0..self.grid.height {
             for x in 0..self.grid.width {
                 if helper::next_float(1.0) < 0.1 {
-                    self.grid.cells[y][x].alive = true;
+                    self.grid.cells[y * self.grid.width + x].alive = true;
                 }
             }
         }
@@ -165,3 +141,4 @@ impl Benchmark for GameOfLife {
         self.grid.compute_hash() + alive
     }
 }
+

--- a/rust/src/benchmarks/nbody.rs
+++ b/rust/src/benchmarks/nbody.rs
@@ -3,7 +3,6 @@ use super::super::{helper, Benchmark};
 const SOLAR_MASS: f64 = 4.0 * std::f64::consts::PI * std::f64::consts::PI;
 const DAYS_PER_YEAR: f64 = 365.24;
 
-#[derive(Clone)]
 struct Planet {
     x: f64,
     y: f64,
@@ -27,10 +26,8 @@ impl Planet {
         }
     }
 
-    fn move_from_i(&mut self, bodies: &mut [Planet], nbodies: usize, dt: f64, i: usize) {
-        let mut j = i;
-        while j < nbodies {
-            let b2 = &mut bodies[j];
+    fn advance(&mut self, following: &mut [Planet], dt: f64) {
+        for b2 in following {
             let dx = self.x - b2.x;
             let dy = self.y - b2.y;
             let dz = self.z - b2.z;
@@ -46,7 +43,6 @@ impl Planet {
             b2.vx += dx * b_mass_mag;
             b2.vy += dy * b_mass_mag;
             b2.vz += dz * b_mass_mag;
-            j += 1;
         }
 
         self.x += dt * self.vx;
@@ -167,9 +163,8 @@ impl Benchmark for Nbody {
         for _ in 0..1000 {
             let mut i = 0;
             while i < nbodies {
-                let mut b = self.bodies[i].clone();
-                b.move_from_i(&mut self.bodies, nbodies, dt, i + 1);
-                self.bodies[i] = b;
+                let (before, following) = self.bodies.split_at_mut(i + 1);
+                before[i].advance(following, dt);
                 i += 1;
             }
         }

--- a/rust/src/benchmarks/neural_net.rs
+++ b/rust/src/benchmarks/neural_net.rs
@@ -11,6 +11,7 @@ const TARGET_1: [f64; 1] = [1.0];
 struct Synapse {
     weight: f64,
     prev_weight: f64,
+    // Indices within the source and destination layers of this connection.
     source_neuron: usize,
     dest_neuron: usize,
 }
@@ -56,55 +57,68 @@ impl Neuron {
     fn derivative(&self) -> f64 {
         self.output * (1.0 - self.output)
     }
+
+    fn calculate_output(&mut self, sources: &[Neuron], synapses: &[Synapse]) {
+        let mut activation = 0.0;
+        for &synapse_idx in &self.synapses_in {
+            let synapse = &synapses[synapse_idx];
+            activation += synapse.weight * sources[synapse.source_neuron].output;
+        }
+        activation -= self.threshold;
+        self.output = 1.0 / (1.0 + (-activation).exp());
+    }
+
+    fn update_weights(&mut self, rate: f64, sources: &[Neuron], synapses: &mut [Synapse]) {
+        for &synapse_idx in &self.synapses_in {
+            let synapse = &mut synapses[synapse_idx];
+            let source_output = sources[synapse.source_neuron].output;
+            let temp_weight = synapse.weight;
+            synapse.weight += (rate * Self::LEARNING_RATE * self.error * source_output)
+                + (Self::MOMENTUM * (synapse.weight - synapse.prev_weight));
+            synapse.prev_weight = temp_weight;
+        }
+
+        let temp_threshold = self.threshold;
+        self.threshold += (rate * Self::LEARNING_RATE * self.error * -1.0)
+            + (Self::MOMENTUM * (self.threshold - self.prev_threshold));
+        self.prev_threshold = temp_threshold;
+    }
 }
 
 #[derive(Clone)]
 struct NeuralNetwork {
-    input_layer: Vec<usize>,
-    hidden_layer: Vec<usize>,
-    output_layer: Vec<usize>,
-    neurons: Vec<Neuron>,
+    input_layer: Vec<Neuron>,
+    hidden_layer: Vec<Neuron>,
+    output_layer: Vec<Neuron>,
     synapses: Vec<Synapse>,
 }
 
 impl NeuralNetwork {
     fn new(inputs: usize, hidden: usize, outputs: usize) -> Self {
-        let total_neurons = inputs + hidden + outputs;
-        let mut neurons = Vec::with_capacity(total_neurons);
-        for _ in 0..total_neurons {
-            neurons.push(Neuron::new());
-        }
-
-        let input_layer: Vec<usize> = (0..inputs).collect();
-        let hidden_layer: Vec<usize> = (inputs..inputs + hidden).collect();
-        let output_layer: Vec<usize> = (inputs + hidden..inputs + hidden + outputs).collect();
-
+        let mut input_layer: Vec<_> = (0..inputs).map(|_| Neuron::new()).collect();
+        let mut hidden_layer: Vec<_> = (0..hidden).map(|_| Neuron::new()).collect();
+        let mut output_layer: Vec<_> = (0..outputs).map(|_| Neuron::new()).collect();
         let mut synapses = Vec::new();
 
-        for &source_idx in &input_layer {
-            for &dest_idx in &hidden_layer {
-                let synapse_idx = synapses.len();
-                synapses.push(Synapse::new(source_idx, dest_idx));
-                neurons[source_idx].synapses_out.push(synapse_idx);
-                neurons[dest_idx].synapses_in.push(synapse_idx);
-            }
-        }
-
-        for &source_idx in &hidden_layer {
-            for &dest_idx in &output_layer {
-                let synapse_idx = synapses.len();
-                synapses.push(Synapse::new(source_idx, dest_idx));
-                neurons[source_idx].synapses_out.push(synapse_idx);
-                neurons[dest_idx].synapses_in.push(synapse_idx);
-            }
-        }
+        Self::connect(&mut input_layer, &mut hidden_layer, &mut synapses);
+        Self::connect(&mut hidden_layer, &mut output_layer, &mut synapses);
 
         Self {
             input_layer,
             hidden_layer,
             output_layer,
-            neurons,
             synapses,
+        }
+    }
+
+    fn connect(sources: &mut [Neuron], destinations: &mut [Neuron], synapses: &mut Vec<Synapse>) {
+        for (source_idx, source) in sources.iter_mut().enumerate() {
+            for (dest_idx, dest) in destinations.iter_mut().enumerate() {
+                let synapse_idx = synapses.len();
+                synapses.push(Synapse::new(source_idx, dest_idx));
+                source.synapses_out.push(synapse_idx);
+                dest.synapses_in.push(synapse_idx);
+            }
         }
     }
 
@@ -113,109 +127,40 @@ impl NeuralNetwork {
 
         const RATE: f64 = 0.3;
 
-        for (i, &target) in targets.iter().enumerate() {
-            let neuron_idx = self.output_layer[i];
-
-            let output = self.neurons[neuron_idx].output;
-            let derivative = self.neurons[neuron_idx].derivative();
-            let error = (target - output) * derivative;
-            self.neurons[neuron_idx].error = error;
-
-            let synapses_in = self.neurons[neuron_idx].synapses_in.clone();
-            for &synapse_idx in &synapses_in {
-                let synapse = &mut self.synapses[synapse_idx];
-                let source_output = self.neurons[synapse.source_neuron].output;
-
-                let temp_weight = synapse.weight;
-                synapse.weight += (RATE * Neuron::LEARNING_RATE * error * source_output)
-                    + (Neuron::MOMENTUM * (synapse.weight - synapse.prev_weight));
-                synapse.prev_weight = temp_weight;
-            }
-
-            let neuron = &mut self.neurons[neuron_idx];
-            let temp_threshold = neuron.threshold;
-            neuron.threshold += (RATE * Neuron::LEARNING_RATE * error * -1.0)
-                + (Neuron::MOMENTUM * (neuron.threshold - neuron.prev_threshold));
-            neuron.prev_threshold = temp_threshold;
+        for (neuron, &target) in self.output_layer.iter_mut().zip(targets) {
+            neuron.error = (target - neuron.output) * neuron.derivative();
+            neuron.update_weights(RATE, &self.hidden_layer, &mut self.synapses);
         }
 
-        let mut hidden_errors = vec![0.0; self.hidden_layer.len()];
-
-        for (i, &neuron_idx) in self.hidden_layer.iter().enumerate() {
-            let neuron = &self.neurons[neuron_idx];
+        for neuron in &mut self.hidden_layer {
             let mut sum = 0.0;
-
             for &synapse_idx in &neuron.synapses_out {
                 let synapse = &self.synapses[synapse_idx];
-
-                sum += synapse.prev_weight * self.neurons[synapse.dest_neuron].error;
+                sum += synapse.prev_weight * self.output_layer[synapse.dest_neuron].error;
             }
-
-            hidden_errors[i] = sum * neuron.derivative();
-        }
-
-        for (i, &neuron_idx) in self.hidden_layer.iter().enumerate() {
-            let error = hidden_errors[i];
-            self.neurons[neuron_idx].error = error;
-
-            let synapses_in = self.neurons[neuron_idx].synapses_in.clone();
-            for &synapse_idx in &synapses_in {
-                let synapse = &mut self.synapses[synapse_idx];
-                let source_output = self.neurons[synapse.source_neuron].output;
-
-                let temp_weight = synapse.weight;
-                synapse.weight += (RATE * Neuron::LEARNING_RATE * error * source_output)
-                    + (Neuron::MOMENTUM * (synapse.weight - synapse.prev_weight));
-                synapse.prev_weight = temp_weight;
-            }
-
-            let neuron = &mut self.neurons[neuron_idx];
-            let temp_threshold = neuron.threshold;
-            neuron.threshold += (RATE * Neuron::LEARNING_RATE * error * -1.0)
-                + (Neuron::MOMENTUM * (neuron.threshold - neuron.prev_threshold));
-            neuron.prev_threshold = temp_threshold;
+            neuron.error = sum * neuron.derivative();
+            neuron.update_weights(RATE, &self.input_layer, &mut self.synapses);
         }
     }
 
     fn feed_forward(&mut self, inputs: &[f64]) {
-        for (i, &input) in inputs.iter().enumerate() {
-            let neuron_idx = self.input_layer[i];
-            self.neurons[neuron_idx].output = input;
+        for (neuron, &input) in self.input_layer.iter_mut().zip(inputs) {
+            neuron.output = input;
         }
 
-        for &neuron_idx in &self.hidden_layer {
-            let mut activation = 0.0;
-            let neuron = &self.neurons[neuron_idx];
-
-            for &synapse_idx in &neuron.synapses_in {
-                let synapse = &self.synapses[synapse_idx];
-                activation += synapse.weight * self.neurons[synapse.source_neuron].output;
-            }
-            activation -= neuron.threshold;
-
-            let output = 1.0 / (1.0 + (-activation).exp());
-            self.neurons[neuron_idx].output = output;
+        for neuron in &mut self.hidden_layer {
+            neuron.calculate_output(&self.input_layer, &self.synapses);
         }
 
-        for &neuron_idx in &self.output_layer {
-            let mut activation = 0.0;
-            let neuron = &self.neurons[neuron_idx];
-
-            for &synapse_idx in &neuron.synapses_in {
-                let synapse = &self.synapses[synapse_idx];
-                activation += synapse.weight * self.neurons[synapse.source_neuron].output;
-            }
-            activation -= neuron.threshold;
-
-            let output = 1.0 / (1.0 + (-activation).exp());
-            self.neurons[neuron_idx].output = output;
+        for neuron in &mut self.output_layer {
+            neuron.calculate_output(&self.hidden_layer, &self.synapses);
         }
     }
 
     fn current_outputs(&self) -> Vec<f64> {
         self.output_layer
             .iter()
-            .map(|&idx| self.neurons[idx].output)
+            .map(|neuron| neuron.output)
             .collect()
     }
 }
@@ -275,3 +220,4 @@ impl Benchmark for NeuralNet {
         helper::checksum_f64(sum)
     }
 }
+

--- a/rust/src/benchmarks/template.rs
+++ b/rust/src/benchmarks/template.rs
@@ -136,7 +136,7 @@ impl Benchmark for TemplateRegex {
             self.base.vars.get(key).map(|s| s.as_str()).unwrap_or("")
         });
 
-        self.base.rendered = rendered.to_string();
+        self.base.rendered = rendered.into_owned();
         self.base.checksum = self
             .base
             .checksum


### PR DESCRIPTION
This is the more involved changeset than my previous #15; also touches enough benchmarks to potentially having some non-negligible effect on the leaderbord.
It tries to be more Rust-ideomatic when managing memory, while getting closer to C++/Crystal data layout and management.

NeuralNet is the biggest gain: 3×, due to both less copying and moving to the three layer vectors plus synapse list data structure, like the C++ and Crystal versions do.

Weirdly, there was no noticeable performance gain in Nbody, despite this replacing cloning with in-place mutation.
I also suspect that Game of Life used to have a legitimate UB (due to raw-pointer `&Cell` aliasing in the `Grid<'static>`), and the new flat vector impl doesn't require any manual lifetime bookkeeping (which is always a good sign).