### PR TITLE
Set `Xmx` for Java

### DIFF
--- a/java/run
+++ b/java/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 rm -f ./target/java-benchmarks-1.0-SNAPSHOT.jar
 mvn compile package -Pjava-plain -DskipTests -Dmaven.test.skip=true -q
-../xtime.rb java -server -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar ../run.js $@
+../xtime.rb java -Xmx512m -server -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar ../run.js $@


### PR DESCRIPTION
This reduces memory consumption with no effect on runtime based on testing.

There is obviously quite a bit of variance when running on a local machine (laptop) with other applications running. These are the numbers  I got:

| mode | time elapsed (s) | mem usage (MB) |
|---|---:|---:|
| default | 75.7706 | 2534.2 |
| `Xmx=512m` | 73.8865 | 664.8 |

In this particular run, setting `Xmx` results in both lower runtime and lower memory usage.