### PR TITLE
Add run config to use Serial GC for Java/OpenJDK and Java/GraalVM/JIT

### DIFF
--- a/benchmarks.rb
+++ b/benchmarks.rb
@@ -1685,6 +1685,28 @@ RUNS = [
     run_cmd: <<~CMD.chomp,
       java \
         -Xmx8g \
+        -Dfile.encoding=UTF-8 \
+        -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar
+    CMD
+    version_cmd: "java --version",
+    dir: "/src/java",
+    container: "java",
+    group: :prod,
+    deps_cmd: "mvn dependency:resolve; mvn dependency:resolve-plugins",
+  ),
+
+  Run.new(
+    name: "Java/OpenJDK/Serial",
+    build_cmd: <<~CMD.chomp,
+      mvn compile package -Pjava-plain \
+        -DskipTests \
+        -Dmaven.test.skip=true \
+        -q
+    CMD
+    binary_name: "./target/java-benchmarks-1.0-SNAPSHOT.jar",
+    run_cmd: <<~CMD.chomp,
+      java \
+        -Xmx512m \
         -XX:+UseSerialGC \
         -Dfile.encoding=UTF-8 \
         -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar
@@ -1728,6 +1750,33 @@ RUNS = [
 
   Run.new(
     name: "Java/GraalVM/JIT",
+    build_cmd: <<~CMD.chomp,
+      mvn compile package -Pgraalvm-jit \
+        -DskipTests \
+        -Dmaven.test.skip=true \
+        -q
+    CMD
+    binary_name: "./target/java-benchmarks-1.0-SNAPSHOT.jar",
+    run_cmd: <<~CMD.chomp,
+      java \
+        -Dfile.encoding=UTF-8 \
+        -XX:+UseG1GC \
+        -XX:+EnableJVMCI \
+        -XX:+UseJVMCICompiler \
+        -Djvmci.Compiler=graal \
+        -XX:-TieredCompilation \
+        -Xmx8g \
+        -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar
+    CMD
+    version_cmd: "java --version",
+    dir: "/src/java",
+    container: "graalvm",
+    group: :prod,
+    deps_cmd: "mvn dependency:resolve; mvn dependency:resolve-plugins",
+  ),
+ 
+  Run.new(
+    name: "Java/GraalVM/JIT/Serial",
     build_cmd: <<~CMD.chomp,
       mvn compile package -Pgraalvm-jit \
         -DskipTests \

--- a/benchmarks.rb
+++ b/benchmarks.rb
@@ -1714,7 +1714,7 @@ RUNS = [
     version_cmd: "java --version",
     dir: "/src/java",
     container: "java",
-    group: :prod,
+    group: :hack,
     deps_cmd: "mvn dependency:resolve; mvn dependency:resolve-plugins",
   ),
 
@@ -1776,7 +1776,7 @@ RUNS = [
   ),
  
   Run.new(
-    name: "Java/GraalVM/JIT/Serial",
+    name: "Java/GraalVM/Serial",
     build_cmd: <<~CMD.chomp,
       mvn compile package -Pgraalvm-jit \
         -DskipTests \
@@ -1798,7 +1798,7 @@ RUNS = [
     version_cmd: "java --version",
     dir: "/src/java",
     container: "graalvm",
-    group: :prod,
+    group: :hack,
     deps_cmd: "mvn dependency:resolve; mvn dependency:resolve-plugins",
   ),
 

--- a/benchmarks.rb
+++ b/benchmarks.rb
@@ -1685,6 +1685,7 @@ RUNS = [
     run_cmd: <<~CMD.chomp,
       java \
         -Xmx8g \
+        -XX:+UseSerialGC \
         -Dfile.encoding=UTF-8 \
         -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar
     CMD
@@ -1737,7 +1738,7 @@ RUNS = [
     run_cmd: <<~CMD.chomp,
       java \
         -Dfile.encoding=UTF-8 \
-        -XX:+UseG1GC \
+        -XX:+UseSerialGC \
         -XX:+EnableJVMCI \
         -XX:+UseJVMCICompiler \
         -Djvmci.Compiler=graal \


### PR DESCRIPTION
I observed faster benchmark times and lower memory usage across the board.

Tested on WSL2 on Win11.

Java/OpenJDK:
Before: 56.253s, 507.69Mb
After: 49.498s, 169.739Mb

GraalVM/JIT: 
Before: 50.004s, 536.358Mb
After: 45.469s, 371.024Mb