### PR TITLE
Set Xmx to 512m for Java/OpenJDK and Java/GraalVM/JIT

### DIFF
--- a/benchmarks.rb
+++ b/benchmarks.rb
@@ -1684,7 +1684,7 @@ RUNS = [
     binary_name: "./target/java-benchmarks-1.0-SNAPSHOT.jar",
     run_cmd: <<~CMD.chomp,
       java \
-        -Xmx8g \
+        -Xmx512m \
         -Dfile.encoding=UTF-8 \
         -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar
     CMD
@@ -1742,7 +1742,7 @@ RUNS = [
         -XX:+UseJVMCICompiler \
         -Djvmci.Compiler=graal \
         -XX:-TieredCompilation \
-        -Xmx8g \
+        -Xmx512m \
         -jar ./target/java-benchmarks-1.0-SNAPSHOT.jar
     CMD
     version_cmd: "java --version",


### PR DESCRIPTION
My testing shows the following

| Benchmark | Heap | Time | Memory |
|---|---:|---:|---:|
| Java/OpenJDK | Xmx8g | 56.253s | 507.69MB |
| Java/OpenJDK | Xmx1g | 51.906s | 328.708 MB |
| Java/OpenJDK | Xmx512m | 51.168s | 250.62 MB |
| Java/GraalVM/JIT | Xmx8g | 50.004s | 536.358MB |
| Java/GraalVM/JIT | Xmx1g | 49.201s | 424.1 MB |
| Java/GraalVM/JIT | Xmx512m | 49.683s | 377.644 MB |